### PR TITLE
Bugfix: stop didn't actually remove listeners

### DIFF
--- a/httpServer.js
+++ b/httpServer.js
@@ -19,7 +19,7 @@ module.exports = {
 
     stop: function () {
         Server.stop();
-        DeviceEventEmitter.removeListener('httpServerResponseReceived');
+        DeviceEventEmitter.removeAllListeners('httpServerResponseReceived');
     },
 
     respond: function (requestId, code, type, body) {


### PR DESCRIPTION
DeviceEventEmitter.removeListener requires the listener to be passed in as the second argument. Without this, it does nothing.

DeviceEventEmitter.removeAllListeners will remove all listeners for a given event.